### PR TITLE
Add simple dredd image with node 0.12

### DIFF
--- a/dredd/Dockerfile
+++ b/dredd/Dockerfile
@@ -1,0 +1,5 @@
+from node:0.12
+
+RUN npm install -g dredd
+
+CMD dredd


### PR DESCRIPTION
- this can be using for dredd testing without NodeJS (for example python
  apps).