### PR TITLE
Add PyYAML to dependencies

### DIFF
--- a/sphinx-doc-dev/Dockerfile
+++ b/sphinx-doc-dev/Dockerfile
@@ -7,10 +7,11 @@ COPY requirements.txt /tmp/
 
 RUN apt-get clean && \
     apt-get update && \
-    apt-get install -y --no-install-recommends python-sphinx \
-    graphviz \
-    make \
-    python-pip && \
+    apt-get install -y --no-install-recommends \
+        python-sphinx \
+        graphviz \
+        make \
+        python-pip && \
     pip install -r /tmp/requirements.txt && \
     rm -rf /usr/share/doc/* && \
     rm -rf /usr/share/locale/* && \

--- a/sphinx-doc-dev/Dockerfile
+++ b/sphinx-doc-dev/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get clean && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         python-sphinx \
+        python-yaml \
         graphviz \
         make \
         python-pip && \


### PR DESCRIPTION
We have started to use YAML to specify intersphinx dependencies, and we do use PyYAML to parse it. 