### PR TITLE
Update nodejs to 0.12.12

### DIFF
--- a/nodejs-0.12-dev/Dockerfile
+++ b/nodejs-0.12-dev/Dockerfile
@@ -2,7 +2,7 @@ FROM        apiaryio/base-dev-debian-minimal
 MAINTAINER  Apiary <sre@apiary.io>
 
 ENV REFRESHED_AT 2016-02-10
-ENV NODE_VERSION v0.12.11
+ENV NODE_VERSION v0.12.12
 ENV NPM_VERSION 2.14.7
 
 RUN apt-get clean && \


### PR DESCRIPTION
- https://nodejs.org/en/blog/release/v0.12.12/
- DROWN attack

https://trello.com/c/mYZvitlF/303-cve-2016-0800-drown