### PR TITLE
Removed latexpdf bulding from default command

### DIFF
--- a/sphinx-doc-npm-dev/Dockerfile
+++ b/sphinx-doc-npm-dev/Dockerfile
@@ -16,4 +16,4 @@ RUN mkdir /mnt/lib
 WORKDIR /mnt/lib
 VOLUME ["/mnt/lib"]
 
-CMD ["make", "clean", "html", "latexpdf"]
+CMD ["make", "clean", "html"]


### PR DESCRIPTION
Since this image inherited from `apiaryio/base-sphinx-doc-dev` which doesn't have latex installed we can remove it. Also I didn't find any usage of it, because in core app is default command overriden to `make clean html`

Or if latexpdf is required, we have to inherit from: `sphinx-latex-doc-dev`