### PR TITLE
Fix build coreapp-dev for debian

### DIFF
--- a/coreapp-dev/Dockerfile
+++ b/coreapp-dev/Dockerfile
@@ -6,12 +6,11 @@ ENV REFRESHED_AT 2010-06-24
 USER root
 RUN apt-get install -y wget \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10 \
-    && echo "deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.0.list \
+    && echo "deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/3.0 main" | tee /etc/apt/sources.list.d/mongodb-org-3.0.list \
     && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
     && sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-    && dpkg --add-architecture i386 \
     && apt-get update \
-    && apt-get install -y mongodb-org-shell=3.0.8 google-chrome-stable libgtk2.0-0:i386 xvfb php5-common php5-cli php5-curl libkrb5-dev ruby-dev build-essential libssl-dev \
+    && apt-get install -y mongodb-org-shell=3.0.8 google-chrome-stable xvfb php5-common php5-cli php5-curl libkrb5-dev ruby-dev build-essential libssl-dev \
     && /sbin/ldconfig -v \
     && gem install rest-client \
     && apt-get install -y redis-tools


### PR DESCRIPTION
- we use debian instead ubuntu
- problem with `i386` switch, this not supported for `google-chrome-stable` 