### PR TITLE
apiaryio/nodejs:0.12 - npm 2.15.11 + script updates

### DIFF
--- a/nodejs/0.12/Dockerfile
+++ b/nodejs/0.12/Dockerfile
@@ -1,7 +1,8 @@
 FROM        node:0.12
 MAINTAINER  Apiary <sre@apiary.io>
 
-ENV REFRESHED_AT 2016-09-28
+ENV REFRESHED_AT 2016-10-04
+ENV NPM_VERSION=2.15.11
 
 USER root
 RUN apt-get update && \
@@ -13,3 +14,5 @@ RUN apt-get update && \
     rm -rf /var/cache/debconf/*-old && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /usr/share/doc/*
+
+RUN npm install -g npm@$NPM_VERSION

--- a/scripts/docker-build-images.sh
+++ b/scripts/docker-build-images.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+echo "CIRCLE_COMPARE_URL: $CIRCLE_COMPARE_URL"
+echo "REBUILD_ALL: $REBUILD_ALL"
+echo "DRY_RUN: $DRY_RUN"
+
 if [[ -z "$CIRCLE_COMPARE_URL" || "$REBUILD_ALL" ]]; then
     REBUILD_ALL=1
 else
@@ -20,7 +25,7 @@ if [ $REBUILD_ALL == 0 ]; then
     CHANGED_FILES=`git diff --name-only $SHA1 $SHA2`
 fi
 
-python ./scripts/build-images.py -a $REBUILD_ALL -f "$CHANGED_FILES"
+python ./scripts/build-images.py -a $REBUILD_ALL -f "$CHANGED_FILES" -t "$DRY_RUN"
 EXIT_CODE=$?
 if [ $EXIT_CODE -ne 0 ]; then
     exit $EXIT_CODE


### PR DESCRIPTION
- locked npm version at 2.15.11 for apiaryio/nodejs:0.12
- scripts: only rebuild the relevant tag for tagged images
- scripts: added dry-run argument to test out scripts
- scripts: do not rebuild all images upon script change (we have REBUILD_ALL env var if needed)