### PR TITLE
Update NodeJS 4 image to latest security release 4.6.2

### DIFF
--- a/nodejs/4/Dockerfile
+++ b/nodejs/4/Dockerfile
@@ -1,7 +1,7 @@
 FROM        node:argon
 MAINTAINER  Apiary <sre@apiary.io>
 
-ENV REFRESHED_AT 2016-10-19
+ENV REFRESHED_AT 2016-11-10
 
 USER root
 RUN apt-get update && \


### PR DESCRIPTION
I am using latests nodejs in https://github.com/apiaryio/apiary/pull/4312 so I want update also base images to have same version