### PR TITLE
feat: update npm to v4.1.1 for node v4

### DIFF
--- a/nodejs/4/Dockerfile
+++ b/nodejs/4/Dockerfile
@@ -2,6 +2,7 @@ FROM        node:argon
 MAINTAINER  Apiary <sre@apiary.io>
 
 ENV REFRESHED_AT 2016-12-20
+ENV NPM_VERSION=4.1.1
 
 USER root
 
@@ -17,3 +18,5 @@ RUN apt-get update && \
     rm -rf /var/cache/debconf/*-old && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /usr/share/doc/*
+
+RUN npm install -g npm@$NPM_VERSION


### PR DESCRIPTION
Took the gist from https://github.com/apiaryio/docker-base-images/blob/debfd79f92623aaffe42c28c88ca5c27ef7ce5e3/nodejs/0.12/Dockerfile