### PR TITLE
feat: locked Chrome at version 55 for coreapp:4

### DIFF
--- a/coreapp/4/Dockerfile
+++ b/coreapp/4/Dockerfile
@@ -1,13 +1,15 @@
 FROM        apiaryio/nodejs:4
 MAINTAINER  Apiary <sre@apiary.io>
 
-ENV REFRESHED_AT 2017-03-16
+ENV REFRESHED_AT 2017-03-17
 
 ENV MONGO_MAJOR 3.2
 ENV MONGO_VERSION 3.2.11
 ENV MONGO_GPG=EA312927
-
+ENV CHROME_VERSION=55.0.2883.75
 USER root
+COPY chrome64_$CHROME_VERSION.deb /tmp/chrome64_$CHROME_VERSION.deb
+
 RUN apt-get install -y wget \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv $MONGO_GPG \
     && echo "deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/$MONGO_MAJOR main" > /etc/apt/sources.list.d/mongodb-org.list \
@@ -27,8 +29,11 @@ RUN apt-get install -y wget \
                           libssl-dev \
                           redis-tools \
                           vnc4server \
+    && dpkg -i /tmp/chrome64_$CHROME_VERSION.deb \
     && gem install rest-client \
     && /sbin/ldconfig -v
+
+RUN rm /tmp/chrome64_$CHROME_VERSION.deb
 
 RUN npm install -g coffee-script@1.11.0 grunt-cli@1.2.0
 RUN npm install -g node-gyp


### PR DESCRIPTION
including the .deb package as it's not retrievable from official mirrors and might be a trick to download it eventually