### PR TITLE
chore: upgrade nodejs to latest december 2017 versions

### DIFF
--- a/nodejs/4/Dockerfile
+++ b/nodejs/4/Dockerfile
@@ -1,7 +1,7 @@
 FROM        node:argon
 MAINTAINER  Apiary <sre@apiary.io>
 
-ENV REFRESHED_AT 2017-07-12
+ENV REFRESHED_AT 2017-12-13
 ENV NPM_VERSION=4.4.4
 
 USER root

--- a/nodejs/6/Dockerfile
+++ b/nodejs/6/Dockerfile
@@ -1,7 +1,7 @@
 FROM        node:boron
 MAINTAINER  Apiary <sre@apiary.io>
 
-ENV REFRESHED_AT 2017-10-05
+ENV REFRESHED_AT 2017-12-13
 ENV NPM_VERSION=4.6.1
 
 USER root

--- a/nodejs/8/Dockerfile
+++ b/nodejs/8/Dockerfile
@@ -1,7 +1,7 @@
 FROM        node:carbon
 MAINTAINER  Apiary <sre@apiary.io>
 
-ENV REFRESHED_AT 2017-11-15
+ENV REFRESHED_AT 2017-12-13
 ENV NPM_VERSION=4.6.1
 
 USER root


### PR DESCRIPTION
https://nodejs.org/en/blog/vulnerability/december-2017-security-releases/