### PR TITLE
Prepare node 8 with npm 6

### DIFF
--- a/coreapp/8-npm6-chrome-stable/Dockerfile
+++ b/coreapp/8-npm6-chrome-stable/Dockerfile
@@ -1,0 +1,34 @@
+FROM        apiaryio/nodejs:8-npm6
+MAINTAINER  Apiary <sre@apiary.io>
+
+ENV REFRESHED_AT 2018-06-05
+
+ENV MONGO_MAJOR 3.2
+ENV MONGO_VERSION 3.2.15
+ENV MONGO_GPG=EA312927
+USER root
+
+RUN apt-get install -y wget \
+    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv $MONGO_GPG \
+    && echo "deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/$MONGO_MAJOR main" > /etc/apt/sources.list.d/mongodb-org.list \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y mongodb-org-shell=$MONGO_VERSION \
+                          google-chrome-stable \
+                          xvfb \
+                          php5-common \
+                          php5-cli \
+                          php5-curl \
+                          libkrb5-dev \
+                          ruby \
+                          ruby-dev \
+                          build-essential \
+                          libssl-dev \
+                          redis-tools \
+                          vnc4server \
+    && gem install rest-client \
+    && /sbin/ldconfig -v
+
+RUN npm install -g coffee-script@1.11.0 grunt-cli@1.2.0
+RUN npm install -g node-gyp

--- a/nodejs/8-npm6/Dockerfile
+++ b/nodejs/8-npm6/Dockerfile
@@ -1,0 +1,22 @@
+FROM        node:carbon
+MAINTAINER  Apiary <sre@apiary.io>
+
+ENV REFRESHED_AT 2018-06-05
+ENV NPM_VERSION=6.1.0
+
+USER root
+
+# due to https://github.com/nodejs/docker-node/commit/4a722c29c0e52624af8b72b4711ebeba8ea39463
+RUN userdel node
+
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    apt-get clean -y && \
+    apt-get autoclean -y && \
+    apt-get autoremove -y && \
+    rm -rf /usr/share/locale/* && \
+    rm -rf /var/cache/debconf/*-old && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /usr/share/doc/*
+
+RUN npm install -g npm@$NPM_VERSION


### PR DESCRIPTION
After upgrading to node 8, we need these images to prepare a PR similar to https://github.com/apiaryio/apiary/pull/5491