### PR TITLE
Add clang 6 docker image

### DIFF
--- a/clang/6/Dockerfile
+++ b/clang/6/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:16.04
+
+ENV CLANG_VERSION=6.0.0
+
+RUN apt-get update && \
+    apt-get install -y curl xz-utils python build-essential && \
+    curl -sL -o /tmp/clang-$CLANG_VERSION.tar.xz.sig http://releases.llvm.org/$CLANG_VERSION/clang+llvm-$CLANG_VERSION-x86_64-linux-gnu-ubuntu-16.04.tar.xz.sig && \
+    curl -sL -o /tmp/clang-$CLANG_VERSION.tar.xz http://releases.llvm.org/$CLANG_VERSION/clang+llvm-$CLANG_VERSION-x86_64-linux-gnu-ubuntu-16.04.tar.xz && \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B6C8F98282B944E3B0D5C2530FC3042E345AD05D && \
+    gpg --verify /tmp/clang-$CLANG_VERSION.tar.xz.sig && \
+    tar xvf /tmp/clang-$CLANG_VERSION.tar.xz -C /opt && \
+    rm -fr /tmp/*
+
+ENV CC=clang
+ENV CXX=clang++
+ENV PATH="/opt/clang+llvm-$CLANG_VERSION-x86_64-linux-gnu-ubuntu-16.04/bin:${PATH}"
+
+CMD bash


### PR DESCRIPTION
This PR adds a clang docker image for clang:6 using the binaries that Clang provides for Ubuntu 16.04. Clang is a compiler that we support in Drafter. I want to get this PR out as a start, but I will be following up with clang/4 and clang/5 afterwards as we want to test in multiple versions for Drafter.

We will need to create the `apiaryio/clang` docker repo on DockerHub as mentioned in the README for new images. As I do not have credentials I will need help from SRE to do this task beforehand.

#### Tasks

- [x] Create `apiaryio/clang` repo on DockerHub