### PR TITLE
Update tagging and deploy oraclelinux and golang images

### DIFF
--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:alpine
 MAINTAINER sre@apiary.io
 
-ENV REFRESHED_AT 2018-10-26
+ENV REFRESHED_AT 2018-10-31
 
 RUN apk add --update git

--- a/golang/glide/Dockerfile
+++ b/golang/glide/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang
 MAINTAINER sre@apiary.io
 
-ENV REFRESHED_AT 2018-10-26
+ENV REFRESHED_AT 2018-10-31
 
 RUN curl -L -o glide.tar.gz https://github.com/Masterminds/glide/releases/download/v0.13.1/glide-v0.13.1-linux-amd64.tar.gz \
     && tar -zxf glide.tar.gz \

--- a/oraclelinux/node8/Dockerfile
+++ b/oraclelinux/node8/Dockerfile
@@ -1,7 +1,7 @@
 FROM        oraclelinux:7-slim
 MAINTAINER  Apiary <sre@apiary.io>
 
-ENV REFRESHED_AT 2018-10-10
+ENV REFRESHED_AT 2018-10-31
 ENV NPM_VERSION 5.6.0
 
 USER root

--- a/oraclelinux/python36/Dockerfile
+++ b/oraclelinux/python36/Dockerfile
@@ -1,7 +1,7 @@
 FROM        oraclelinux:7-slim
 MAINTAINER  Apiary <sre@apiary.io>
 
-ENV REFRESHED_AT 2018-10-10
+ENV REFRESHED_AT 2018-10-31
 
 USER root
 

--- a/scripts/build-images.py
+++ b/scripts/build-images.py
@@ -24,8 +24,10 @@ class DockerImage:
 
         if self.versioned:
             self.tag = self.name
-            self.name = os.path.split(os.path.dirname(df_location))[1]
-            self.full_name = "apiaryio/{0}:{1}".format(self.name, self.tag)
+        else
+            self.tag = 'latest'
+        self.full_name = "apiaryio/{0}:{1}".format(self.name, self.tag)
+        self.print_name = "apiaryio/{0}_{1}".format(self.name, self.tag)
 
     def _extra_build(self):
         df_location = os.path.dirname(self.dockerfile)
@@ -129,7 +131,7 @@ else:
                     print('Error building {0}'.format(image.full_name))
                     sys.exit(1)
                 print("Saving {0}...".format(image.full_name))
-                subprocess.call("docker save {0} > \"/tmp/{1}.tar\"".format(image.full_name, image.name), shell=True)
+                subprocess.call("docker save {0} > \"/tmp/{1}.tar\"".format(image.full_name, image.print_name), shell=True)
                 print("Saved {0}".format(image.full_name))
 
     tmp_image_file = open("/tmp/images", 'w')

--- a/scripts/build-images.py
+++ b/scripts/build-images.py
@@ -20,14 +20,13 @@ class DockerImage:
     def _set_name(self):
         df_location = os.path.dirname(self.dockerfile)
         self.name = os.path.split(df_location)[1]
-        self.full_name = "apiaryio/" + self.name
-
         if self.versioned:
             self.tag = self.name
-        else
+            self.name = os.path.split(os.path.dirname(df_location))[1]
+        else:
             self.tag = 'latest'
         self.full_name = "apiaryio/{0}:{1}".format(self.name, self.tag)
-        self.print_name = "apiaryio/{0}_{1}".format(self.name, self.tag)
+        self.print_name = "{0}_{1}".format(self.name, self.tag)
 
     def _extra_build(self):
         df_location = os.path.dirname(self.dockerfile)


### PR DESCRIPTION
- the tagging process was off if building both the latest and a tagged image - only one of those would get saved and the deploy pipeline would fail on the squashing step - this PR fixes the behaviour and updates the golang and oraclelinux images so they get deployed properly