### PR TITLE
Add Node 12 image for oraclelinux

### DIFF
--- a/oraclelinux/node12/Dockerfile
+++ b/oraclelinux/node12/Dockerfile
@@ -1,0 +1,23 @@
+FROM        oraclelinux:7-slim
+MAINTAINER  Apiary <sre@apiary.io>
+
+ENV REFRESHED_AT 2020-09-25
+ENV NODEJS_VERSION_MAJOR 12
+ENV NPM_VERSION 6.13.4
+
+USER root
+
+RUN yum install -y oracle-nodejs-release-el7 \
+    && yum-config-manager --enable ol7_developer_nodejs${NODEJS_VERSION_MAJOR} \
+    && yum install -y nodejs \
+    && yum install -y gcc gcc-c++ autoconf automake make \
+    && npm i -g npm@${NPM_VERSION} \
+    && yum clean all \
+    && mkdir -p /app
+
+WORKDIR /app
+
+RUN node -v
+RUN npm -v
+
+ENTRYPOINT [ "bash" ]


### PR DESCRIPTION
Node 10 is approaching (in next ~6 months) end of life. Node 12 is the active LTS.

To aid review:

```diff
$ diff node10/Dockerfile node12/Dockerfile
4,6c4,6
< ENV REFRESHED_AT 2020-02-28
< ENV NODEJS_VERSION_MAJOR 10
< ENV NPM_VERSION 6.4.1
---
> ENV REFRESHED_AT 2020-09-25
> ENV NODEJS_VERSION_MAJOR 12
> ENV NPM_VERSION 6.13.4
```