### PR TITLE
fix: change python image entrypoint

### DIFF
--- a/oraclelinux/python36/Dockerfile
+++ b/oraclelinux/python36/Dockerfile
@@ -1,7 +1,7 @@
 FROM        oraclelinux:7-slim
-MAINTAINER  Apiary <sre@apiary.io>
+LABEL       maintainer="Apiary <sre@apiary.io>"
 
-ENV REFRESHED_AT 2020-11-02
+ENV REFRESHED_AT 2021-02-02
 
 USER root
 
@@ -9,4 +9,4 @@ RUN yum install -y yum-utils && yum-config-manager --enable ol7_developer_EPEL &
     yum install -y scl-utils python36 python36-setuptools && \
     easy_install-3.6 pip
 
-ENTRYPOINT [ "python36" ]
+ENTRYPOINT [ "/usr/bin/python3" ]


### PR DESCRIPTION
When trying to run the image I kept getting `docker: Error response from daemon: OCI runtime create failed: container_linux.go:370: starting container process caused: exec: "python36": executable file not found in $PATH: unknown.` error. This entrypoint seems to fix the issue.

Is this the correct way to do it, though?